### PR TITLE
Refactor Dockerfile to run lavamusic as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,14 @@ COPY --from=builder /opt/lavamusic/src/utils/LavaLogo.txt ./src/utils/LavaLogo.t
 COPY package*.json ./
 RUN npm install --only=production
 
+# Run as non-root user
+RUN addgroup --gid 322 --system lavamusic && \
+    adduser --uid 322 --system lavamusic
+
+# Change ownership of the folder
+RUN chown -R lavamusic:lavamusic /opt/lavamusic/
+
+# Switch to the appropriate user
+USER lavamusic
+
 CMD [ "node", "dist/index.js" ]


### PR DESCRIPTION
As a security measure, this pull request refactors the Dockerfile to utilize a non-root user. 
It addresses potential security risks associated with running processes with elevated privileges which are also unnecessary for the operation of a lavamusic instance.