### PR TITLE
Update README.md and LavaLink example.application.yml

### DIFF
--- a/Lavalink/example.application.yml
+++ b/Lavalink/example.application.yml
@@ -113,7 +113,7 @@ lavalink:
       channelMix: true
       lowPass: true
     bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses. Duration <= 0 to disable JDA-NAS. Minimum of 40ms, lower values may introduce pauses.
-    frameBufferDurationMs: 1000 # How many milliseconds of audio to keep buffered
+    frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
     opusEncodingQuality: 10 # Opus encoder quality. Valid values range from 0 to 10, where 10 is best quality but is the most expensive on the CPU.
     resamplingQuality: MEDIUM # Quality of resampling operations. Valid values are LOW, MEDIUM and HIGH, where HIGH uses the most CPU.
     trackStuckThresholdMs: 10000 # The threshold for how long a track can be stuck. A track is stuck if does not return any audio data.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@
 -   ![TikTok](https://img.shields.io/badge/TikTok-FF2D55?style=plastic&logo=tiktok&logoColor=white) ([Required Plugin][skybot-lavalink-plugin])
 -   ![Soundgasm](https://img.shields.io/badge/Soundgasm-F1672F?style=plastic&logo=soundgasm&logoColor=white) ([Required Plugin][skybot-lavalink-plugin])
 -   ![Text To Speech](https://img.shields.io/badge/Text%20To%20Speech-3080ff?style=plastic&logo=google-translate&logoColor=white) ([Required Plugin][skybot-lavalink-plugin])
-[LavaSrc]: https://github.com/TopiSenpai/LavaSrc
+
+[LavaSrc]: https://github.com/topi314/LavaSrc
 [skybot-lavalink-plugin]: https://github.com/DuncteBot/skybot-lavalink-plugin
 [youtube-source]: https://github.com/lavalink-devs/youtube-source
+
 To Setup a Lavalink server on Windows, Linux, or Replit, [Click Here.](https://github.com/LucasB25/lavalink-server)
 ### **Need Help with plugins?** Join our [Discord Server](https://discord.gg/YsJCtDuTXp) and ask for help in the `#support` channel.
 


### PR DESCRIPTION
- Fixed the display of links in ReadME.md
- Fixed links to LavaSrc plugin in ReadME.md file sources
- Changed the default value of `frameBufferDurationMs` to the recommended value in the LavaLink documentation - `5000`