### PR TITLE
Update InteractionCreate.ts

### DIFF
--- a/src/events/client/InteractionCreate.ts
+++ b/src/events/client/InteractionCreate.ts
@@ -21,9 +21,12 @@ export default class InteractionCreate extends Event {
     public async run(interaction: CommandInteraction | AutocompleteInteraction): Promise<any> {
         if (interaction instanceof CommandInteraction && interaction.isCommand()) {
             const setup = await this.client.db.getSetup(interaction.guildId);
-            if (setup && interaction.channelId === setup.textId) {
+            const allowedCategories = ["filters", "music", "playlist"];
+            const commandInSetup = this.client.commands.get(interaction.commandName);
+
+            if (setup && interaction.channelId === setup.textId && (!commandInSetup || !allowedCategories.includes(commandInSetup.category))) {
                 return await interaction.reply({
-                    content: `You can't use commands in setup channel.`,
+                    content: `You can't use this command in setup channel.`,
                     ephemeral: true,
                 });
             }
@@ -169,7 +172,12 @@ export default class InteractionCreate extends Event {
             }
 
             try {
-                await command.run(this.client, ctx, ctx.args);
+                const reply = await command.run(this.client, ctx, ctx.args);
+                if (setup && interaction.channelId === setup.textId && allowedCategories.includes(command.category)) {
+                    setTimeout(() => {
+                        interaction.deleteReply().catch(() => {});
+                    }, 5000);
+                }
             } catch (error) {
                 this.client.logger.error(error);
                 await interaction.reply({


### PR DESCRIPTION
- Changed the methodology of blocking the execution of commands on setupchannel by adding category exceptions related to setupchannel, so that commands such as filters, /play, create can be executed on setupchannel while maintaining the blocking of the execution of other commands outside the exceptions)  [Currently only slashcomends],
- Added that the change from point 1 should be adjusted under the previous channel operation, by adding deletion of messages (from command exceptions) after 5 seconds have elapsed.