### PR TITLE
Update example.application.yml

### DIFF
--- a/Lavalink/example.application.yml
+++ b/Lavalink/example.application.yml
@@ -159,7 +159,7 @@ lavalink:
       snapshot: false # set to true if you want to use snapshot builds
     - dependency: "com.github.topi314.sponsorblock:sponsorblock-plugin:3.0.1"
       snapshot: false # set to true if you want to use snapshot builds
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.11.5"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.12.0"
       snapshot: false # set to true if you want to use snapshot builds
   pluginsDir: './plugins'
   server:


### PR DESCRIPTION
###  Update youtube-plugin to latest release

This fixes the `SignatureCipherManager : Problematic YouTube player script` error in Lavalink when queuing Youtube links.

[https://github.com/lavalink-devs/youtube-source/releases/tag/1.12.0](https://github.com/lavalink-devs/youtube-source/releases/tag/1.12.0)