### PR TITLE
Fix double equals typo in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,9 @@ LOG_CHANNEL_ID="" # If you enter this, you will be able to receive the status of
 LOG_COMMANDS_ID="" # The channel ID where command usage logs will be sent.
 BOT_STATUS="online" # Your bot status (online, dnd, idle, invisible or offline).
 BOT_ACTIVITY_TYPE=0 # Activity type is a number from 0 to 5. See more here: https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-types
-BOT_ACTIVITY=="Lavamusic" # Your bot activity.
+BOT_ACTIVITY="Lavamusic" # Your bot activity.
 DATABASE_URL="" # Your database url (If you want to use sqlite, then you can leave it blank.).
-AUTO_NODE=="false" # true for auto node. It is given from lavainfo-api (https://lavainfo-api.deno.dev).
+AUTO_NODE="false" # true for auto node. It is given from lavainfo-api (https://lavainfo-api.deno.dev).
 SEARCH_ENGINE="YouTubeMusic" # Search engine to be used when playing the song. You can use: YouTube, YouTubeMusic, SoundCloud, Spotify, Apple, Deezer, Yandex and JioSaavn
 GENIUS_API="" # Sign up and get your own api at (https://genius.com/) to fetch your lyrics (CLIENT TOKEN)
 NODES=[{"id":"Local Node","host":"lavalink","port":2333,"authorization":"youshallnotpass","retryAmount":5,"retryDelay":60000,"secure":"false"}]


### PR DESCRIPTION
Fixes the double equals sign in `.env.example` that leads to `Error: No available Node was found, please add a LavalinkNode to the Manager via Manager.NodeManager#createNode`.