### PR TITLE
Added queue duration indicator to queue command

### DIFF
--- a/locales/EnglishUS.json
+++ b/locales/EnglishUS.json
@@ -335,7 +335,8 @@
 			"live": "LIVE",
 			"track_info": "{index}. [{title}]({uri}) - Requested By: <@{requester}> - Duration: `{duration}`",
 			"title": "Queue",
-			"page_info": "Page {index} of {total}"
+			"page_info": "Page {index} of {total}",
+			"duration": "Queue Duration: `{totalDuration}`"
 		},
 		"remove": {
 			"description": "Removes a song from the queue",

--- a/src/commands/music/Queue.ts
+++ b/src/commands/music/Queue.ts
@@ -75,7 +75,10 @@ export default class Queue extends Command {
 					name: ctx.locale('cmd.queue.title'),
 					iconURL: ctx.guild.icon ? ctx.guild.iconURL()! : ctx.author?.displayAvatarURL(),
 				})
-				.setDescription(chunk.join('\n'))
+				.setDescription(chunk.join('\n')
+					+ '\n\n' + ctx.locale('cmd.queue.duration', {
+						totalDuration: client.utils.formatTime(player.queue.utils.totalDuration() - player.queue.current?.info.duration!),
+					}))
 				.setFooter({
 					text: ctx.locale('cmd.queue.page_info', {
 						index: index + 1,


### PR DESCRIPTION
Changes the queue command to include the queue's total duration.

![queue duration](https://github.com/user-attachments/assets/c3a05316-149b-443b-9cb3-c4b72cd3cbdc)
